### PR TITLE
LEARN-01: Monorepo Scaffold + GitHub Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-ticket.md
+++ b/.github/ISSUE_TEMPLATE/bug-ticket.md
@@ -1,0 +1,29 @@
+---
+name: "🐞 Bug / Fix Ticket"
+about: Report or track a fix or improvement in any module
+title: "FIX-##: brief description"
+labels: ["bug"]
+---
+
+### 🔧 Summary
+
+Describe the issue or bug in clear terms.
+
+### 🧪 Steps to Reproduce
+
+1. …
+2. …
+3. …
+
+### ✅ Expected Behavior
+
+Explain what should happen.
+
+### 🧰 Environment (if relevant)
+
+- App: [e.g., day1-tooltip-vanilla]
+- Browser / Node version:
+
+### 📎 Additional Notes
+
+Optional links, screenshots, or console output.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📘 Project README
+    url: https://github.com/vneilly/frontend-motion-lab#readme
+    about: Review project overview and module structure.

--- a/.github/ISSUE_TEMPLATE/feature-ticket.md
+++ b/.github/ISSUE_TEMPLATE/feature-ticket.md
@@ -1,0 +1,32 @@
+---
+name: "💡 Feature / Learning Ticket"
+about: Document a scoped task, experiment, or feature in the Frontend Motion Lab
+title: "LEARN-##: short, clear title"
+labels: ["enhancement"]
+---
+
+### 🧩 Description
+
+A brief summary of what this ticket covers — e.g., feature goal, learning objective, or experiment.
+
+### 🎯 Acceptance Criteria
+
+- [ ] Clear, verifiable outcomes or deliverables
+- [ ] Any required documentation or demo page updates
+
+### 🔍 Notes / Context
+
+Include any background context, references, or relevant links.  
+If this ticket contributes to a larger module (e.g., Day 1 Tooltip), mention it here.
+
+### ⏱ Level of Effort
+
+- [ ] S (≤1h)
+- [ ] M (≤3h)
+- [ ] L (>3h)
+
+---
+
+**Commit Convention:**  
+`feat(day#): short description`  
+Example: `feat(day1): implement basic tooltip hover/focus behavior`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+## 🧩 Summary
+
+Briefly describe the purpose of this PR.  
+Include which module, feature, or learning objective it supports.
+
+---
+
+## 🔖 Related Ticket(s)
+
+Closes #<ISSUE_ID>  
+Or: Part of #<ISSUE_ID>
+
+---
+
+## ✅ Acceptance Criteria
+
+- [ ] Code or assets added meet the ticket requirements.
+- [ ] Demo app or package builds and runs locally.
+- [ ] README or docs updated if necessary.
+- [ ] Lint/build passes in CI.
+
+---
+
+## 🧠 Notes / Context
+
+Add any relevant reasoning, decisions, or references (e.g., ADR link, design note, or learning takeaway).
+
+---
+
+## 🧾 Level of Effort
+
+- [ ] S (≤1h)
+- [ ] M (≤3h)
+- [ ] L (>3h)
+
+---

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "frontend-motion-lab",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "pnpm -r --if-present build",
+    "lint": "pnpm -r --if-present lint",
+    "test": "pnpm -r --if-present test"
+  },
+  "keywords": [],
+  "author": "Vernon E. Neilly II",
+  "license": "MIT"
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "apps/*"
+  - "packages/*"


### PR DESCRIPTION
## 🧩 Summary
Implements the initial monorepo scaffold for **frontend-motion-lab** and adds GitHub Issue/PR templates. 

---

## 🔖 Related Ticket(s)
N/A

---

## ✅ Acceptance Criteria
- [x] pnpm workspace initialized with `apps/*` and `packages/*`
- [x] MIT license confirmed in package.json
- [x] `.github` directory created with Issue and PR templates
- [x] `pnpm-workspace.yaml` validated
- [x] Folders `apps/` and `packages/` created

---

## 🧠 Notes / Context
This PR creates the baseline project structure.  
CI and README will be added next under LEARN-01 before final merge.

---

## 🧾 Level of Effort
- [x] S (≤1h)

---

**Branch Naming Convention:**  
`feature/LEARN-01-monorepo-setup`

**Commit Style:**  
`feat(repo): add issue and PR templates`