### PR TITLE
LEARN-01: Add CI Workflow, .gitignore, Lockfile, and README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 9.12.0
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: Monorepo - Install, Lint, Build
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install
+        run: pnpm install
+
+      - name: Lint (if present)
+        run: pnpm -r --if-present lint
+
+      - name: Build (if present)
+        run: pnpm -r --if-present build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Dependencies
+node_modules/
+
+# Builds / bundles
+dist/
+build/
+
+# Test artifacts
+coverage/
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Env & secrets
+.env
+.env.*
+!.env.example
+
+# OS / editor
+.DS_Store
+Thumbs.db
+.vscode/
+
+# Tooling caches (add as needed)
+.turbo/
+.vercel/
+.next/
+.cache/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# Frontend Motion Lab
+
+A structured frontend motion lab exploring high-performance DOM interactions, animation patterns, and React architecture for modern UI systems.
+
+---
+
+## 📖 Overview
+
+**Frontend Motion Lab** is a curated collection of small, production-style projects focused on mastering interactive UI development.  
+Each module builds toward real-world skills — from vanilla JavaScript DOM manipulation to animation-driven React components and performance optimization with canvas, `useRef`, and context providers.
+
+---
+
+## 🧩 Repository
+
+frontend-motion-lab/
+├── apps/ # Project-based learning modules
+├── packages/ # Reusable code and libraries
+├── docs/ # Notes, ADRs, and learning reflections
+└── .github/ # CI, issue, and PR templates
+
+---
+
+## ⚙️ Monorepo Tooling
+
+- **Package manager:** pnpm 9.12.0 (workspace-based)
+- **Node version:** 22.x
+- **CI:** GitHub Actions (`.github/workflows/ci.yml`)
+
+---
+
+## 🧠 Learning Focus
+
+- Efficient DOM updates and reactivity patterns
+- Animation timing, `requestAnimationFrame`, and CSS transitions
+- Bridging legacy DOM (e.g., jQuery) with React via `MutationObserver`
+- Scalable React Context state management
+- Building reusable motion-oriented UI libraries (e.g., **Smart Tooltip System**)
+
+---
+
+## 🪴 Contribution & Workflow
+
+Each task or learning module is tracked via **GitHub Issues** and follows a clear PR process.  
+Branches use the format `feature/<TICKET-ID>-slug`, and commits follow **Conventional Commits**.
+
+---
+
+© 2025 Vernon E. Neilly II · Licensed under the MIT License

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "pnpm -r --if-present lint",
     "test": "pnpm -r --if-present test"
   },
+  "packageManager": "pnpm@9.12.0",
   "keywords": [],
   "author": "Vernon E. Neilly II",
   "license": "MIT"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}


### PR DESCRIPTION
## 🧩 Summary  
Adds a descriptive CI workflow, root `.gitignore`, committed `pnpm-lock.yaml`, and README to complete LEARN-01 setup.  This finalizes the monorepo foundation. 

---

## 🔖 Related Ticket(s)  
Closes #1  

---

## ✅ Acceptance Criteria  
- [x] `.github/workflows/ci.yml` added with descriptive workflow name  
- [x] `.gitignore` created with monorepo-friendly ignores  
- [x] `pnpm-lock.yaml` committed for caching and deterministic installs  
- [x] `packageManager` pinned to `pnpm@9.12.0`  
- [x] `README.md` added  

---

## 🧠 Notes / Context  
Lockfile commit enables caching in CI.  
This completes the initial scaffold before moving to **LEARN-02: Shared Utilities**.  

---

## 🧾 Level of Effort  
- [x] S (≤ 1 h)  

---

**Branch Naming Convention:**  
feature/learn-01-ci-readme  

**Commit Style:**  
chore(repo): add CI workflow, lockfile, and README  