### PR TITLE
LEARN-03A: Scaffold @vn2/smart-tooltip package

### DIFF
--- a/packages/smart-tooltip/README.md
+++ b/packages/smart-tooltip/README.md
@@ -1,0 +1,56 @@
+# @vn2/smart-tooltip
+
+Smart Tooltip System — an interactive tooltip utility for demos and micro-libraries built with vanilla JavaScript and TypeScript.
+
+---
+
+## 🧭 Overview
+
+This package provides the baseline for the Smart Tooltip System used across Frontend Motion Lab.  
+It demonstrates progressive enhancement from basic DOM hover tooltips to modular class-based APIs.
+
+---
+
+## ⚙️ Install / Workspace Setup
+
+Run this command from the repo root:
+
+pnpm --filter @vn2/smart-tooltip build
+
+This ensures the package compiles and is linked within the workspace.
+
+---
+
+## 🧱 Usage (stub)
+
+Example import:
+
+import { **version } from "@vn2/smart-tooltip";
+console.log(**version);
+
+> Functional API will be added in later LEARN-03 tickets.
+
+---
+
+## 🧩 Dev Commands
+
+| Command    | Description                     |
+| ---------- | ------------------------------- |
+| pnpm build | Compile TypeScript into `dist/` |
+| pnpm lint  | Run ESLint checks               |
+| pnpm test  | Run Vitest (once implemented)   |
+
+---
+
+## 🧠 Design Notes
+
+- ESM-only module
+- SSR-safe by default
+- Reuses shared-utils for viewport, rAF, and measurement helpers
+- Focused on DOM events, positioning, and accessibility
+
+---
+
+## 📄 License
+
+MIT

--- a/packages/smart-tooltip/package.json
+++ b/packages/smart-tooltip/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@vn2/smart-tooltip",
+  "version": "0.0.1",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint src",
+    "test": "vitest"
+  }
+}

--- a/packages/smart-tooltip/src/index.ts
+++ b/packages/smart-tooltip/src/index.ts
@@ -1,0 +1,1 @@
+export const __version = "0.0.1";

--- a/packages/smart-tooltip/tsconfig.json
+++ b/packages/smart-tooltip/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "isolatedModules": true,
+    "noEmit": false
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,8 @@ importers:
 
   packages/shared-utils: {}
 
+  packages/smart-tooltip: {}
+
 packages:
 
   '@esbuild/aix-ppc64@0.25.11':


### PR DESCRIPTION
## 🧾 Summary
Introduces the `@vn2/smart-tooltip` workspace package and integrates it with the monorepo toolchain (pnpm, TypeScript, ESLint). This is structural scaffolding only; no runtime tooltip logic yet.

---

## ✅ Completed Work
- ESM-only package scaffold under `packages/smart-tooltip/`
- `package.json` with exports/types and scripts (build/lint/test)
- `tsconfig.json` extending root base; outputs to `dist/`
- `src/index.ts` placeholder export for build validation
- `README.md` with Overview, Install/Workspace, Usage (stub), Dev Commands, and Design Notes
- Verified:
  - `pnpm --filter @vn2/smart-tooltip build`
  - `pnpm --filter @vn2/smart-tooltip lint`

---

## 🔗 Notes / Context
Foundation for upcoming LEARN-03B–03G tickets (vanilla tooltip prototype → class-based SmartTooltip + demos). Keeps docs and structure consistent with `@vn2/shared-utils`.

---

## 🎯 Acceptance Criteria
- [x] Package directory, entrypoint, and build config exist
- [x] Build and lint pass within the workspace
- [x] README scaffold added

---

## 🧾 LOE
S (≤1h)

**Branch**
feature/learn-03a-scaffold-smart-tooltip
Closes #4 