### PR TITLE
LEARN-03c: add keyboard focus + ARIA support to tooltip

### DIFF
--- a/apps/tooltip-vanilla/src/main.ts
+++ b/apps/tooltip-vanilla/src/main.ts
@@ -4,13 +4,25 @@ import { show, move, hide } from "./tooltip";
 const OFFSET_X = 12;
 const OFFSET_Y = 12;
 
+const TOOLTIP_ID = "stp-tooltip";
+
+function setDescribedBy(el: HTMLElement) {
+  el.setAttribute("aria-describedby", TOOLTIP_ID);
+}
+
+function clearDescribedBy(el: HTMLElement) {
+  if (el.getAttribute("aria-describedby") === TOOLTIP_ID) {
+    el.removeAttribute("aria-describedby");
+  }
+}
+
 document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
 <h1>Tooltip (Vanilla)</h1>
 <p>Hover the elements below to see the tooltip follow your cursor.</p>
   <div class="demo-grid">
     <button data-tooltip="Primary action">Primary Button</button>
     <button data-tooltip="Secondary action">Secondary Button</button>
-    <div data-tooltip="Card with details" class="vn-card">
+    <div data-tooltip="Card with details" class="vn-card" tabindex="0">
       Hover over this card
     </div>
   </div>
@@ -35,7 +47,27 @@ function wireHoverTooltips(selector = "[data-tooltip]") {
   });
 }
 
+function wireFocusTooltips(selector = "[data-tooltip]") {
+  const nodes = document.querySelectorAll<HTMLElement>(selector);
+
+  nodes.forEach((el) => {
+    el.addEventListener("focus", () => {
+      const text = el.getAttribute("data-tooltip") ?? "";
+      show(text);
+      setDescribedBy(el);
+      const rect = el.getBoundingClientRect();
+      move(rect.left + rect.width + OFFSET_X, rect.top);
+    });
+
+    el.addEventListener("blur", () => {
+      hide();
+      clearDescribedBy(el);
+    });
+  });
+}
+
 wireHoverTooltips();
+wireFocusTooltips();
 
 window.addEventListener("keydown", (e) => {
   if (e.key === "Escape") {
@@ -45,4 +77,11 @@ window.addEventListener("keydown", (e) => {
 
 window.addEventListener("blur", () => {
   hide();
+});
+
+window.addEventListener("mouseout", (e) => {
+  const to = e.relatedTarget as Element | null;
+  if (!to) {
+    hide();
+  }
 });

--- a/apps/tooltip-vanilla/src/tooltip.ts
+++ b/apps/tooltip-vanilla/src/tooltip.ts
@@ -4,6 +4,8 @@ const OFFSCREEN = "-9999px, -9999px";
 function createRoot(): HTMLDivElement {
   const el = document.createElement("div");
   el.className = "stp-root";
+  el.id = "stp-tooltip";
+  el.setAttribute("role", "tooltip");
   el.setAttribute("data-visible", "false");
   el.textContent = "";
   document.body.appendChild(el);


### PR DESCRIPTION
### Summary
Enhances the Day 1 vanilla tooltip demo with keyboard and screen reader support.

Closes #9.

### Details
- Added stable `id="stp-tooltip"` and `role="tooltip"` for ARIA relationships.
- Added `focus` / `blur` listeners to `[data-tooltip]` triggers.
- Dynamically sets and clears `aria-describedby` for focused elements.
- Maintains consistency between hover and keyboard-driven tooltips.

### Testing
- Tab/Shift+Tab navigates between triggers and shows tooltip near focused element.
- Tooltip hides on Esc, window blur, or pointer leave.
- Screen readers announce the tooltip text correctly while focused.

### Next Steps
Integrate `withinViewport()` from shared utils to handle positioning intelligently (LEARN-03D).