### PR TITLE
LEARN-03D - add withinViewport-based clamping to tooltip positioning

### DIFF
--- a/apps/tooltip-vanilla/package.json
+++ b/apps/tooltip-vanilla/package.json
@@ -11,5 +11,8 @@
   "devDependencies": {
     "typescript": "~5.9.3",
     "vite": "^7.1.7"
+  },
+  "dependencies": {
+    "@vn2/shared-utils": "workspace:*"
   }
 }

--- a/apps/tooltip-vanilla/src/main.ts
+++ b/apps/tooltip-vanilla/src/main.ts
@@ -1,8 +1,11 @@
 import "./style.css";
-import { show, move, hide } from "./tooltip";
 
-const OFFSET_X = 12;
-const OFFSET_Y = 12;
+import { withinViewport } from "@vn2/shared-utils";
+
+import { show, move, hide, getRoot } from "./tooltip";
+
+const OFFSET = 12; // distance away from cursor/target so we don't obsure it.
+const PAD = 8; // margin from viewport edges for tidy UI/UX.
 
 const TOOLTIP_ID = "stp-tooltip";
 
@@ -38,7 +41,14 @@ function wireHoverTooltips(selector = "[data-tooltip]") {
 
     el.addEventListener("mousemove", (e) => {
       const ev = e as MouseEvent;
-      move(ev.clientX + OFFSET_X, ev.clientY + OFFSET_Y);
+
+      const desiredX = ev.clientX + OFFSET;
+      const desiredY = ev.clientY + OFFSET;
+
+      const { width, height } = getRoot().getBoundingClientRect();
+      const { x, y } = withinViewport(desiredX, desiredY, width, height, PAD);
+
+      move(x, y);
     });
 
     el.addEventListener("mouseleave", () => {
@@ -55,8 +65,21 @@ function wireFocusTooltips(selector = "[data-tooltip]") {
       const text = el.getAttribute("data-tooltip") ?? "";
       show(text);
       setDescribedBy(el);
-      const rect = el.getBoundingClientRect();
-      move(rect.left + rect.width + OFFSET_X, rect.top);
+      // const rect = el.getBoundingClientRect();
+      // move(rect.left + rect.width + OFFSET, rect.top);
+
+      const targetRect = el.getBoundingClientRect();
+
+      // measure current tooltip box (singleton)
+      const tipRect = getRoot().getBoundingClientRect();
+
+      let preferredX = targetRect.left + targetRect.width / 2 - tipRect.width / 2;
+      let preferredY = targetRect.top - tipRect.height - OFFSET;
+
+      // clamp to viewport - no clips
+      const { x, y } = withinViewport(preferredX, preferredY, tipRect.width, tipRect.height, PAD);
+
+      move(x, y);
     });
 
     el.addEventListener("blur", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,10 @@ importers:
         version: 4.0.3
 
   apps/tooltip-vanilla:
+    dependencies:
+      '@vn2/shared-utils':
+        specifier: workspace:*
+        version: link:../../packages/shared-utils
     devDependencies:
       typescript:
         specifier: ~5.9.3


### PR DESCRIPTION
### Summary
Improves tooltip positioning logic by integrating the shared utility `withinViewport` to prevent clipping near screen edges.

Closes #10.

### Details
- Imported `withinViewport` from `@vn2/shared-utils`.
- Introduced shared constants `OFFSET` and `PAD` for spacing and edge padding.
- Updated hover and focus handlers to clamp tooltip coordinates based on measured tooltip size.
- Ensured consistent, accessible behavior on narrow or constrained viewports.

### Testing
- Hover targets near viewport edges → tooltip remains fully visible.
- Tab through elements and resize window → tooltip stays within viewport bounds.
- No behavioral regressions from LEARN-03C (focus/ARIA parity).

### Next Steps
Implement movement throttling and animation smoothness using `rafThrottle` from shared utils (LEARN-03E).